### PR TITLE
add requirements.txt; fix ws path so it is derived from the window; server hosts all devices

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,12 @@
+aiohttp==3.8.3
+aiosignal==1.3.1
+async-timeout==4.0.2
+attrs==22.2.0
+charset-normalizer==2.1.1
+frozenlist==1.3.3
+idna==3.4
+multidict==6.0.4
+numpy==1.24.1
+scipy==1.10.0
+websockets==10.4
+yarl==1.8.2

--- a/server/__main__.py
+++ b/server/__main__.py
@@ -152,7 +152,7 @@ class OpServer(Greeks):
         
     def start(self):
         loop = asyncio.get_event_loop()
-        serve = websockets.serve(self.serving, 'localhost', 8080)
+        serve = websockets.serve(self.serving, '0.0.0.0', 8080)
         loop.run_until_complete(serve)
         loop.run_forever()
 

--- a/src/App.js
+++ b/src/App.js
@@ -27,8 +27,8 @@ export default class App extends React.Component {
   }
   
   componentDidMount(){
-    
-    const socket = new WebSocket('ws://localhost:8080')
+    const url = new URL(window.location.href)
+    const socket = new WebSocket('ws://' + url.hostname + ':8080')
     socket.onmessage = (evt) => {
       this.setState({ response: JSON.parse(evt.data) })
     }


### PR DESCRIPTION
I noticed there was no requirements.txt so I created one.

Also served this on a different machine than the one I'm using and I noticed hardcoded localhost -> 0.0.0.0 and derive ws path from url.hostname instead. 

Tested locally with `python serve` and `nvm use 16; npm start`